### PR TITLE
ed 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ colored = "1.8.0"
 num_cpus = "1.10.0"
 byteorder = "1.3.2"
 failure = "0.1.6"
-ed = { git = "ssh://git@github.com/FindoraNetwork/ed.git", branch = "main" }
+ed = "0.1.6"
 
 [dependencies.blake2-rfc]
 version = "0.2.18"


### PR DESCRIPTION
Points `ed` back to 0.1.6 as it compiles well on stable Rust